### PR TITLE
Don't inherit from Exporter

### DIFF
--- a/chapter_00/chapter_00.pod
+++ b/chapter_00/chapter_00.pod
@@ -16,10 +16,9 @@ F<XSFun.pm>, content as follows:
 
     use strict;
     use warnings;
-    use Exporter;
     use XSLoader;
 
-    use base 'Exporter';
+    use Exporter 5.57 'import';
 
     our $VERSION     = '0.001';
     our %EXPORT_TAGS = ( 'all' => [] );
@@ -48,7 +47,7 @@ proper F<Makefile>, content as follows:
     WriteMakefile(
         NAME           => 'XSFun',
         VERSION_FROM   => 'lib/XSFun.pm',
-        PREREQ_PM      => { 'Test::More' => 0 },
+        PREREQ_PM      => { 'Test::More' => 0, 'Exporter' => '5.57' },
         ABSTRACT_FROM  => 'lib/XSFun.pm',
         AUTHOR         => 'You',
         LIBS           => [''],

--- a/chapter_01/XSFun/Makefile.PL
+++ b/chapter_01/XSFun/Makefile.PL
@@ -3,7 +3,7 @@ use ExtUtils::MakeMaker;
 WriteMakefile(
     NAME           => 'XSFun',
     VERSION_FROM   => 'lib/XSFun.pm',
-    PREREQ_PM      => { 'Test::More' => 0 },
+    PREREQ_PM      => { 'Test::More' => 0, 'Exporter' => '5.57' },
     ABSTRACT_FROM  => 'lib/XSFun.pm',
     AUTHOR         => 'You',
     LIBS           => [''],

--- a/chapter_01/XSFun/lib/XSFun.pm
+++ b/chapter_01/XSFun/lib/XSFun.pm
@@ -2,10 +2,9 @@ package XSFun;
 
 use strict;
 use warnings;
-use Exporter;
 use XSLoader;
 
-use base 'Exporter';
+use Exporter 5.57 'import';
 
 our $VERSION     = '0.001';
 our %EXPORT_TAGS = ( 'all' => [qw<add_numbers add_numbers_perl>] );

--- a/skeleton/XSFun/Makefile.PL
+++ b/skeleton/XSFun/Makefile.PL
@@ -3,7 +3,7 @@ use ExtUtils::MakeMaker;
 WriteMakefile(
     NAME           => 'XSFun',
     VERSION_FROM   => 'lib/XSFun.pm',
-    PREREQ_PM      => { 'Test::More' => 0 },
+    PREREQ_PM      => { 'Test::More' => 0, 'Exporter' => '5.57' },
     ABSTRACT_FROM  => 'lib/XSFun.pm',
     AUTHOR         => 'You',
     LIBS           => [''],         # e.g., '-lm'

--- a/skeleton/XSFun/lib/XSFun.pm
+++ b/skeleton/XSFun/lib/XSFun.pm
@@ -2,10 +2,9 @@ package XSFun;
 
 use strict;
 use warnings;
-use Exporter;
 use XSLoader;
 
-use base 'Exporter';
+use Exporter 5.57 'import';
 
 our $VERSION     = '0.001';
 our %EXPORT_TAGS = ( 'all' => [] );


### PR DESCRIPTION
`use Exporter 5.57 'import';` instead of `use base 'Exporter;'` because:
- inheriting from Exporter pollutes the namespace
- this avoids loading the legacy `base.pm`

This requires Exporter 5.57+, bundled with perl since 5.8.3 but also available on CPAN.
