### PR TITLE
A use_ok is always useful in a test template

### DIFF
--- a/skeleton/XSFun/t/XSFun.t
+++ b/skeleton/XSFun/t/XSFun.t
@@ -3,7 +3,5 @@ use strict;
 use warnings;
 
 use Test::More tests => 1;
-use XSFun ':all';
 
-ok( 0, 'Write tests ');
-
+use_ok('XSFun', ':all');


### PR DESCRIPTION
(especially for XS code where missing symbols can trigger
perl compilation failures)
