### PR TITLE
Removing trailing whitespace

### DIFF
--- a/chapter_01/XSFun/XSFun.xs
+++ b/chapter_01/XSFun/XSFun.xs
@@ -6,7 +6,7 @@
 
 /* C functions */
 
-MODULE = XSFun		PACKAGE = XSFun		
+MODULE = XSFun		PACKAGE = XSFun
 
 # XS code
 

--- a/chapter_02/XSFun/XSFun.xs
+++ b/chapter_02/XSFun/XSFun.xs
@@ -8,7 +8,7 @@
 
 /* C functions */
 
-MODULE = XSFun		PACKAGE = XSFun		
+MODULE = XSFun		PACKAGE = XSFun
 
 # XS code
 

--- a/chapter_04/chapter_04.pod
+++ b/chapter_04/chapter_04.pod
@@ -111,7 +111,7 @@ a new value in the hash we created in the previous chapter. Let's add it:
             );
 
             SV* const self = newRV_noinc( (SV *)hash );
-    
+
             RETVAL = sv_bless( self, gv_stashpv( class, 0 ) );
         OUTPUT: RETVAL
 
@@ -303,7 +303,7 @@ This, however, will cause a problem, which we will see.
             /* get two items from the stack  */
             /* it starts from 1 in this case */
             SV *key   = ST(i);
-            SV *value = ST( i + 1 ); 
+            SV *value = ST( i + 1 );
 
             /* store the value by key in the hash */
             hv_store_ent( hash, key, value, 0 );


### PR DESCRIPTION
Once upon a time, `particle` had a rant about how much he disliked trailing
whitespace such that we ended up adding a test for it to the coding
standards tests.  Now, many years later, I have a tick that I too don't like
trailing whitespace in text; hence this commit.