### PR TITLE
Various stuff related to tests

### DIFF
--- a/chapter_01/chapter_01.pod
+++ b/chapter_01/chapter_01.pod
@@ -165,9 +165,10 @@ following file F<add_numbers.t>:
     is( add_numbers_perl( 3.1, 4.2 ), 7.3, '3.1 + 4.2 = 7.3' );
     is( add_numbers_perl( 3.2, 4.3 ), 7.5, '3.2 + 4.3 = 7.5' );
 
-Now let's run the tests:
+Now let's run the tests. Note that it's important to rebuild the F<Makefile> so C<make>
+knows about the newly added tests:
 
-    make test
+    perl Makefile.PL && make && make test
 
 You should see output similar to this:
 

--- a/chapter_02/chapter_02.pod
+++ b/chapter_02/chapter_02.pod
@@ -32,7 +32,7 @@ following XS code to C<XSFun.xs>:
             RETVAL = chromaprint_get_version();
         OUTPUT: RETVAL
 
-Let's add a test for it. Create a file F<version.t> with the following:
+Let's add a test for it. Create a file F<t/version.t> with the following:
 
     #!perl
 

--- a/chapter_03/chapter_03.pod
+++ b/chapter_03/chapter_03.pod
@@ -236,7 +236,7 @@ Let's write a test for our code. We can write the following as F<t/version.t>:
     isa_ok( $cp, 'Audio::Chromaprint' );
     can_ok( $cp, 'version'            );
 
-    is( $cp->version, '6.0.0', 'chromaprint version is 6.0.0' );
+    is( $cp->version, '1.2.0', 'chromaprint version is 1.2.0' );
 
 Try it out:
 

--- a/chapter_04/chapter_04.pod
+++ b/chapter_04/chapter_04.pod
@@ -227,7 +227,7 @@ We can simply add this following block to the F<t/new.t> test file:
         like(
             exception { Audio::Chromaprint->new( 1, 2, 3 ) },
             qr{^Expecting key/value pairs as input to constructor},
-            'Incorrect input for odd items (instead of pairs(',
+            'Incorrect input for odd items (instead of pairs)',
         );
 
         is(
@@ -253,7 +253,7 @@ Trying it out...
 
     1..8
     ok 1 - Incorrect input for single item (instead of pairs)
-    ok 2 - Incorrect input for odd items (instead of pairs(
+    ok 2 - Incorrect input for odd items (instead of pairs)
     ok 3 - Successful at calling a constructor without arguments
     ok 4 - Successful at calling a constructor with even items
     ok 5 - The object isa Audio::Chromaprint


### PR DESCRIPTION
This PR addresses several issues.

- when new tests are added, the Makefile.PL needs to be rerun (as mentioned in #31 already)
- in Chapter 2 it didn't say that tests need to be in the t/ directory, but it does so in other chapters
- in Chapter 3 the Chromaprint version in the POD was still 6.0.0 instead of 1.2.0
- in Chapter 4 there was a typo in a test name (but not in the included files)